### PR TITLE
`taxi-proxy` 다시 만들기

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,15 @@
+all:
+	# Makefile for docker compose shortcuts.
+	# For usage, refer to ./Makefile.
+prod-up:
+	# deploy the production environment
+	docker compose -p taxi -f docker-compose.yml up -d
+prod-down:
+	# clean the pre-production environment
+	docker compose -p taxi -f docker-compose.yml down -v
+dev-up:
+	# deploy the pre-production environment
+	docker compose -p taxi -f docker-compose.dev.yml up -d
+dev-down:
+	# clean the pre-production environment
+	docker compose -p taxi -f docker-compose.dev.yml down -v

--- a/README.md
+++ b/README.md
@@ -23,8 +23,7 @@ Environments for dev service
 
 ```
 # Required Environment variables
-FRONT_PORT=
-BACK_PORT=
+PROXY_PORT=
 OG_PORT=
 SESSION_KEY=
 JWT_SECRET_KEY=
@@ -59,8 +58,7 @@ Environments for prod service
 
 ```
 # Required Environment variables
-FRONT_PORT=
-BACK_PORT=
+PROXY_PORT=
 OG_PORT=
 SESSION_KEY=
 JWT_SECRET_KEY=

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -10,7 +10,7 @@ services:
     environment:
       - REACT_APP_FRONT_URL=${FRONT_URL:-https://taxi.dev.sparcs.org}
       - REACT_APP_BACK_URL=${BACK_URL:-https://taxi.dev.sparcs.org/api}
-      - REACT_APP_IO_URL=${IO_URL:-https://taxi.dev.sparcs.org/api}
+      - REACT_APP_IO_URL=${IO_URL:-https://taxi.dev.sparcs.org}
       - REACT_APP_OG_URL=${OG_URL:-https://og-image.taxi.dev.sparcs.org}
       - REACT_APP_S3_URL=${S3_URL:-https://sparcs-taxi-dev.s3.ap-northeast-2.amazonaws.com}
       - REACT_APP_CHANNELTALK_PLUGIN_KEY=${CHANNELTALK_PLUGIN_KEY}

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -5,12 +5,12 @@ services:
     container_name: taxi-front-dev
     restart: always
     image: ${FRONT_IMAGE:-666583083672.dkr.ecr.ap-northeast-2.amazonaws.com/taxi-front:dev}
-    ports:
-      - "${FRONT_PORT:?err}:80"
+    networks:
+      - proxy
     environment:
       - REACT_APP_FRONT_URL=${FRONT_URL:-https://taxi.dev.sparcs.org}
-      - REACT_APP_BACK_URL=${BACK_URL:-https://api.taxi.dev.sparcs.org}
-      - REACT_APP_IO_URL=${IO_URL:-https://api.taxi.dev.sparcs.org}
+      - REACT_APP_BACK_URL=${BACK_URL:-https://taxi.dev.sparcs.org/api}
+      - REACT_APP_IO_URL=${IO_URL:-https://taxi.dev.sparcs.org/api}
       - REACT_APP_OG_URL=${OG_URL:-https://og-image.taxi.dev.sparcs.org}
       - REACT_APP_S3_URL=${S3_URL:-https://sparcs-taxi-dev.s3.ap-northeast-2.amazonaws.com}
       - REACT_APP_CHANNELTALK_PLUGIN_KEY=${CHANNELTALK_PLUGIN_KEY}
@@ -25,14 +25,12 @@ services:
     container_name: taxi-back-dev
     restart: always
     image: ${BACK_IMAGE:-666583083672.dkr.ecr.ap-northeast-2.amazonaws.com/taxi-back:dev}
-    ports:
-      - "${BACK_PORT:?err}:80"
     depends_on:
       - taxi-mongo
       - taxi-redis
-    links:
-      - taxi-mongo:taxi-mongo
-      - taxi-redis:taxi-redis
+    networks:
+      - proxy
+      - backend
     environment:
       - SESSION_KEY=${SESSION_KEY:?err}
       - SPARCSSSO_CLIENT_ID=${SPARCSSSO_CLIENT_ID}
@@ -61,16 +59,32 @@ services:
       - "${OG_PORT:?err}:80"
     depends_on:
       - taxi-back
-    links:
-      - taxi-back:taxi-back
+    networks:
+      - backend
     environment:
       - API_ROOM_INFO=http://taxi-back/rooms/publicInfo?id={}
       - FRONT_URL=${FRONT_URL:-https://taxi.dev.sparcs.org}
+
+  taxi-proxy:
+    container_name: taxi-proxy-dev
+    restart: always
+    image: nginx:1.24.0
+    ports:
+      - "${PROXY_PORT:?err}:80"
+    networks:
+      - proxy
+    depends_on:
+      - taxi-front
+      - taxi-back
+    volumes:
+      - ./taxi-proxy/conf.d:/etc/nginx/conf.d:ro
 
   taxi-mongo:
     container_name: taxi-mongo-dev
     restart: always
     image: mongo:4.4
+    networks:
+      - backend
     volumes:
       - ./taxi-mongo/mongodb.conf:/etc/mongodb.conf
       - taxi-mongo-dev-data:/data/db:rw
@@ -79,6 +93,8 @@ services:
     container_name: taxi-redis-dev
     restart: always
     image: redis:7.0.4-alpine
+    networks:
+      - backend
 
   taxi-watchtower:
     container_name: taxi-watchtower-dev
@@ -108,3 +124,7 @@ volumes:
     external: true
   taxi-ecr-helper-executable:
     external: true
+
+networks:
+  proxy:
+  backend:

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -64,6 +64,9 @@ services:
     environment:
       - API_ROOM_INFO=http://taxi-back/rooms/publicInfo?id={}
       - FRONT_URL=${FRONT_URL:-https://taxi.dev.sparcs.org}
+    labels:
+      - 'com.centurylinklabs.watchtower.lifecycle.pre-update=curl -X POST -H ''Content-type: application/json'' --data ''{"text":"업데이트를 위해 taxi-og-generator-dev 서비스를 종료시켰습니다."}'' ${SLACK_WATCHTOWER_WEBHOOK}'
+      - 'com.centurylinklabs.watchtower.lifecycle.post-update=curl -X POST -H ''Content-type: application/json'' --data ''{"text":"업데이트 후 taxi-og-generator-dev 서비스를 재시작하였습니다."}'' ${SLACK_WATCHTOWER_WEBHOOK}'
 
   taxi-proxy:
     container_name: taxi-proxy-dev

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -129,7 +129,7 @@ services:
       - AWS_REGION=ap-northeast-2
       - AWS_ACCESS_KEY_ID=${AWS_ACCESS_KEY_ID:?err}
       - AWS_SECRET_ACCESS_KEY=${AWS_SECRET_ACCESS_KEY:?err}
-    command: --schedule "0 0 4 * * *" --cleanup --enable-lifecycle-hooks taxi-front taxi-back taxi-og-generator
+    command:  --interval 60 --cleanup --enable-lifecycle-hooks taxi-front taxi-back
     # --schedule "0 0 4 * * *" : 새로운 이미지를 확인하는 6-field cron 표현식 지정
     # --cleanup : 업데이트 후 오래된 이미지 제거
     # --enable-lifecycle-hooks : 컨테이너 업데이트 시 스크립트 실행 활성화

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -144,3 +144,7 @@ volumes:
     external: true
   taxi-ecr-helper-executable:
     external: true
+
+networks:
+  proxy:
+  backend:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,12 +5,12 @@ services:
     container_name: taxi-front
     restart: always
     image: ${FRONT_IMAGE:-666583083672.dkr.ecr.ap-northeast-2.amazonaws.com/taxi-front:latest}
-    ports:
-      - "${FRONT_PORT:?err}:80"
+    networks:
+      - proxy
     environment:
       - REACT_APP_FRONT_URL=${FRONT_URL:-https://taxi.sparcs.org}
-      - REACT_APP_BACK_URL=${BACK_URL:-https://api.taxi.sparcs.org}
-      - REACT_APP_IO_URL=${IO_URL:-https://api.taxi.sparcs.org}
+      - REACT_APP_BACK_URL=${BACK_URL:-https://taxi.sparcs.org/api}
+      - REACT_APP_IO_URL=${IO_URL:-https://taxi.sparcs.org/api}
       - REACT_APP_OG_URL=${OG_URL:-https://og-image.taxi.sparcs.org}
       - REACT_APP_S3_URL=${S3_URL:-https://sparcs-taxi-prod.s3.ap-northeast-2.amazonaws.com}
       - REACT_APP_CHANNELTALK_PLUGIN_KEY=${CHANNELTALK_PLUGIN_KEY}
@@ -30,9 +30,9 @@ services:
     depends_on:
       - taxi-mongo
       - taxi-redis
-    links:
-      - taxi-mongo:taxi-mongo
-      - taxi-redis:taxi-redis
+    networks:
+      - proxy
+      - backend
     environment:
       - SESSION_KEY=${SESSION_KEY:?err}
       - SPARCSSSO_CLIENT_ID=${SPARCSSSO_CLIENT_ID}
@@ -60,16 +60,32 @@ services:
       - "${OG_PORT:?err}:80"
     depends_on:
       - taxi-back
-    links:
-      - taxi-back:taxi-back
+    networks:
+      - backend
     environment:
       - API_ROOM_INFO=http://taxi-back/rooms/publicInfo?id={}
       - FRONT_URL=${FRONT_URL:-https://taxi.sparcs.org}
+
+  taxi-proxy:
+    container_name: taxi-proxy
+    restart: always
+    image: nginx:1.24.0
+    ports:
+      - "${PROXY_PORT:?err}:80"
+    networks:
+      - proxy
+    depends_on:
+      - taxi-front
+      - taxi-back
+    volumes:
+      - ./taxi-proxy/conf.d:/etc/nginx/conf.d:ro
 
   taxi-mongo:
     container_name: taxi-mongo
     restart: always
     image: mongo:4.4
+    networks:
+      - backend
     volumes:
       - ./taxi-mongo/mongodb.conf:/etc/mongodb.conf
       - taxi-mongo-logs:/var/log/mongodb/mongod.log:rw
@@ -79,13 +95,15 @@ services:
     container_name: taxi-redis
     restart: always
     image: redis:7.0.4-alpine
-
+    networks:
+      - backend
+  
   taxi-scheduler:
     container_name: taxi-scheduler
     restart: always
     build: taxi-scheduler
-    links:
-      - taxi-mongo:mongodb
+    networks:
+      - backend
     environment:
       - AWS_ACCESS_KEY_ID=${AWS_ACCESS_KEY_ID:?err}
       - AWS_SECRET_ACCESS_KEY=${AWS_SECRET_ACCESS_KEY:?err}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -63,6 +63,9 @@ services:
     environment:
       - API_ROOM_INFO=http://taxi-back/rooms/publicInfo?id={}
       - FRONT_URL=${FRONT_URL:-https://taxi.sparcs.org}
+    labels:
+      - 'com.centurylinklabs.watchtower.lifecycle.pre-update=curl -X POST -H ''Content-type: application/json'' --data ''{"text":"[PROD] 업데이트를 위해 taxi-og-generator 서비스를 종료시켰습니다."}'' ${SLACK_WATCHTOWER_WEBHOOK}'
+      - 'com.centurylinklabs.watchtower.lifecycle.post-update=curl -X POST -H ''Content-type: application/json'' --data ''{"text":"[PROD] 업데이트 후 taxi-og-generator 서비스를 재시작하였습니다."}'' ${SLACK_WATCHTOWER_WEBHOOK}'
 
   taxi-proxy:
     container_name: taxi-proxy
@@ -127,7 +130,7 @@ services:
       - AWS_REGION=ap-northeast-2
       - AWS_ACCESS_KEY_ID=${AWS_ACCESS_KEY_ID:?err}
       - AWS_SECRET_ACCESS_KEY=${AWS_SECRET_ACCESS_KEY:?err}
-    command:  --interval 60 --cleanup --enable-lifecycle-hooks taxi-front taxi-back
+    command:  --interval 60 --cleanup --enable-lifecycle-hooks taxi-front taxi-back taxi-og-generator
     # --schedule "0 0 4 * * *" : 새로운 이미지를 확인하는 6-field cron 표현식 지정
     # --cleanup : 업데이트 후 오래된 이미지 제거
     # --enable-lifecycle-hooks : 컨테이너 업데이트 시 스크립트 실행 활성화

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -25,8 +25,6 @@ services:
     container_name: taxi-back
     restart: always
     image: ${BACK_IMAGE:-666583083672.dkr.ecr.ap-northeast-2.amazonaws.com/taxi-back:latest}
-    ports:
-      - "${BACK_PORT:?err}:80"
     depends_on:
       - taxi-mongo
       - taxi-redis

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -10,7 +10,7 @@ services:
     environment:
       - REACT_APP_FRONT_URL=${FRONT_URL:-https://taxi.sparcs.org}
       - REACT_APP_BACK_URL=${BACK_URL:-https://taxi.sparcs.org/api}
-      - REACT_APP_IO_URL=${IO_URL:-https://taxi.sparcs.org/api}
+      - REACT_APP_IO_URL=${IO_URL:-https://taxi.sparcs.org}
       - REACT_APP_OG_URL=${OG_URL:-https://og-image.taxi.sparcs.org}
       - REACT_APP_S3_URL=${S3_URL:-https://sparcs-taxi-prod.s3.ap-northeast-2.amazonaws.com}
       - REACT_APP_CHANNELTALK_PLUGIN_KEY=${CHANNELTALK_PLUGIN_KEY}

--- a/taxi-proxy/conf.d/default.conf
+++ b/taxi-proxy/conf.d/default.conf
@@ -1,0 +1,67 @@
+server {
+    listen 80;
+    listen [::]:80;
+    server_name localhost;
+
+    location / {
+		# location이 /로 시작되는 요청들을 프론트엔드로 넘겨줌.
+        proxy_set_header X-Forwarded-For $remote_addr;
+        proxy_set_header Host $http_host;
+
+        proxy_pass http://taxi-front;
+    }
+
+    location ^~ /socket.io {
+		# location이 /socket.io로 시작되는 요청들을 백엔드의 Socket.io 서버에 넘겨줌.
+        proxy_set_header Host $host;
+	    proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+        proxy_set_header X-NginX-Proxy true;
+
+        proxy_http_version 1.1;
+        proxy_set_header Upgrade $http_upgrade;
+        proxy_set_header Connection "upgrade";
+
+        proxy_pass http://taxi-back;
+    }
+
+    location ^~ /admin {
+		# location이 /admin으로 시작되는 요청들을 백엔드의 Express 서버에 넘겨줌.
+		# url에서 '/admin'을 제거하고 백엔드로 넘겨줌.
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+        proxy_set_header X-NginX-Proxy true;
+
+        rewrite  ^/api/(.*) /$1 break;
+        proxy_pass http://taxi-back;
+    }
+
+    location ^~ /docs {
+        # location이 /docs으로 시작되는 요청들을 백엔드의 Express 서버에 넘겨줌.
+	    # url에서 '/docs'을 제거하고 백엔드로 넘겨줌.
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+        proxy_set_header X-NginX-Proxy true;
+
+        rewrite  ^/api/(.*) /$1 break;
+        proxy_pass http://taxi-back;
+    }
+
+    location /api {
+		# location이 /api로 시작되는 요청들을 백엔드의 Express 서버에 넘겨줌.
+		# url에서 '/api'를 제거하고 백엔드로 넘겨줌.
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+        proxy_set_header X-NginX-Proxy true;
+
+        rewrite  ^/api/(.*) /$1 break;
+        proxy_pass http://taxi-back;
+    }
+}


### PR DESCRIPTION
## Summary
It closes #38 
`taxi-front`와 `taxi-back`을 같은 host로 배포하기 위해 `taxi-proxy` 컨테이너를 다시 도입합니다.
dev 서버와 prod(...) 서버에서 테스트 완료하였습니다.

- 관련 이슈
	- `taxi-proxy` 컨테이너 추가: https://github.com/sparcs-kaist/taxi-infra/issues/23
	- `taxi-proxy` 컨테이너 삭제: https://github.com/sparcs-kaist/taxi-infra/issues/35
	- `taxi-proxy` 컨테이너 추가: https://github.com/sparcs-kaist/taxi-infra/issues/38