### PR TITLE
#40 [Bug] `taxi-redis`에 data 볼륨 추가

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,6 +97,8 @@ $ docker volume create taxi-mongo-logs
 taxi-mongo-logs
 $ docker volume create taxi-mongo-data
 taxi-mongo-data
+$ docker volume create taxi-redis-data
+taxi-redis-data
 $ docker volume create taxi-back-logs
 taxi-back-logs
 $ docker volume create taxi-scheduler-logs
@@ -106,5 +108,13 @@ taxi-scheduler-logs
 ### Compose up
 
 ```bash
-docker-compose up -d
+make prod-up # for prod service
+make dev-up # for dev service
+```
+
+### Compose down
+
+```bash
+make prod-down # for prod service
+make dev-down # for dev service
 ```

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -98,6 +98,8 @@ services:
     image: redis:7.0.4-alpine
     networks:
       - backend
+    volumes:
+      - taxi-redis-dev-data:/data:rw
 
   taxi-watchtower:
     container_name: taxi-watchtower-dev
@@ -124,6 +126,8 @@ volumes:
   taxi-back-dev-logs:
     external: true
   taxi-mongo-dev-data:
+    external: true
+  taxi-redis-dev-data:
     external: true
   taxi-ecr-helper-executable:
     external: true

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -98,7 +98,9 @@ services:
     image: redis:7.0.4-alpine
     networks:
       - backend
-  
+    volumes:
+      - taxi-redis-data:/data:rw
+
   taxi-scheduler:
     container_name: taxi-scheduler
     restart: always
@@ -130,7 +132,7 @@ services:
       - AWS_REGION=ap-northeast-2
       - AWS_ACCESS_KEY_ID=${AWS_ACCESS_KEY_ID:?err}
       - AWS_SECRET_ACCESS_KEY=${AWS_SECRET_ACCESS_KEY:?err}
-    command:  --interval 60 --cleanup --enable-lifecycle-hooks taxi-front taxi-back taxi-og-generator
+    command: --interval 60 --cleanup --enable-lifecycle-hooks taxi-front taxi-back taxi-og-generator
     # --schedule "0 0 4 * * *" : 새로운 이미지를 확인하는 6-field cron 표현식 지정
     # --cleanup : 업데이트 후 오래된 이미지 제거
     # --enable-lifecycle-hooks : 컨테이너 업데이트 시 스크립트 실행 활성화
@@ -140,6 +142,8 @@ volumes:
   taxi-mongo-logs:
     external: true
   taxi-mongo-data:
+    external: true
+  taxi-redis-data:
     external: true
   taxi-back-logs:
     external: true


### PR DESCRIPTION
## Summary
It fixes #40 
`taxi-redis` 컨테이너에 `/data` 디렉토리를 docker volume에 바인딩합니다.
그렇지 않으면 redis 컨테이너가 재시작될 때 로그인 세션이 무효화됩니다(앱은 jwt를 사용해 해당 없음).