### PR TITLE
nginx 버전 가리기

### DIFF
--- a/taxi-proxy/conf.d/default.conf
+++ b/taxi-proxy/conf.d/default.conf
@@ -2,9 +2,10 @@ server {
     listen 80;
     listen [::]:80;
     server_name localhost;
+    server_tokens off;
 
     location / {
-		# location이 /로 시작되는 요청들을 프론트엔드로 넘겨줌.
+        # location이 /로 시작되는 요청들을 프론트엔드로 넘겨줌.
         proxy_set_header X-Forwarded-For $remote_addr;
         proxy_set_header Host $http_host;
 
@@ -12,9 +13,9 @@ server {
     }
 
     location ^~ /socket.io {
-		# location이 /socket.io로 시작되는 요청들을 백엔드의 Socket.io 서버에 넘겨줌.
+        # location이 /socket.io로 시작되는 요청들을 백엔드의 Socket.io 서버에 넘겨줌.
         proxy_set_header Host $host;
-	    proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Real-IP $remote_addr;
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
         proxy_set_header X-Forwarded-Proto $scheme;
         proxy_set_header X-NginX-Proxy true;
@@ -27,41 +28,41 @@ server {
     }
 
     location ^~ /admin {
-		# location이 /admin으로 시작되는 요청들을 백엔드의 Express 서버에 넘겨줌.
-		# url에서 '/admin'을 제거하고 백엔드로 넘겨줌.
+        # location이 /admin으로 시작되는 요청들을 백엔드의 Express 서버에 넘겨줌.
+        # url에서 '/admin'을 제거하고 백엔드로 넘겨줌.
         proxy_set_header Host $host;
         proxy_set_header X-Real-IP $remote_addr;
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
         proxy_set_header X-Forwarded-Proto $scheme;
         proxy_set_header X-NginX-Proxy true;
 
-        rewrite  ^/api/(.*) /$1 break;
+        rewrite ^/api/(.*) /$1 break;
         proxy_pass http://taxi-back;
     }
 
     location ^~ /docs {
         # location이 /docs으로 시작되는 요청들을 백엔드의 Express 서버에 넘겨줌.
-	    # url에서 '/docs'을 제거하고 백엔드로 넘겨줌.
+        # url에서 '/docs'을 제거하고 백엔드로 넘겨줌.
         proxy_set_header Host $host;
         proxy_set_header X-Real-IP $remote_addr;
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
         proxy_set_header X-Forwarded-Proto $scheme;
         proxy_set_header X-NginX-Proxy true;
 
-        rewrite  ^/api/(.*) /$1 break;
+        rewrite ^/api/(.*) /$1 break;
         proxy_pass http://taxi-back;
     }
 
     location /api {
-		# location이 /api로 시작되는 요청들을 백엔드의 Express 서버에 넘겨줌.
-		# url에서 '/api'를 제거하고 백엔드로 넘겨줌.
+        # location이 /api로 시작되는 요청들을 백엔드의 Express 서버에 넘겨줌.
+        # url에서 '/api'를 제거하고 백엔드로 넘겨줌.
         proxy_set_header Host $host;
         proxy_set_header X-Real-IP $remote_addr;
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
         proxy_set_header X-Forwarded-Proto $scheme;
         proxy_set_header X-NginX-Proxy true;
 
-        rewrite  ^/api/(.*) /$1 break;
+        rewrite ^/api/(.*) /$1 break;
         proxy_pass http://taxi-back;
     }
 }


### PR DESCRIPTION
## Summary
It fixes #44 
kaist 도메인을 사용하는 웹페이지는 서버 버전을 노출하면 안 됩니다.
nginx 설정을 수정하여 웹서버의 버전이 노출되지 않게 합니다.

## Screenshots

<img width="546" alt="image" src="https://github.com/sparcs-kaist/taxi-infra/assets/46402016/57640e61-bcb1-4e82-a46b-f6ca8983c207">

적용 전(아래), 적용 후(위)