### PR TITLE
#48 [Bug] `X-Forwarded-Proto` 헤더 설정 제거

### DIFF
--- a/taxi-proxy/conf.d/default.conf
+++ b/taxi-proxy/conf.d/default.conf
@@ -17,7 +17,6 @@ server {
         proxy_set_header Host $host;
         proxy_set_header X-Real-IP $remote_addr;
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
-        proxy_set_header X-Forwarded-Proto $scheme;
         proxy_set_header X-NginX-Proxy true;
 
         proxy_http_version 1.1;
@@ -33,7 +32,6 @@ server {
         proxy_set_header Host $host;
         proxy_set_header X-Real-IP $remote_addr;
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
-        proxy_set_header X-Forwarded-Proto $scheme;
         proxy_set_header X-NginX-Proxy true;
 
         rewrite ^/api/(.*) /$1 break;
@@ -46,7 +44,6 @@ server {
         proxy_set_header Host $host;
         proxy_set_header X-Real-IP $remote_addr;
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
-        proxy_set_header X-Forwarded-Proto $scheme;
         proxy_set_header X-NginX-Proxy true;
 
         rewrite ^/api/(.*) /$1 break;
@@ -59,7 +56,6 @@ server {
         proxy_set_header Host $host;
         proxy_set_header X-Real-IP $remote_addr;
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
-        proxy_set_header X-Forwarded-Proto $scheme;
         proxy_set_header X-NginX-Proxy true;
 
         rewrite ^/api/(.*) /$1 break;


### PR DESCRIPTION
## Summary

It fixes #48 
`taxi-proxy` nginx 컨테이너에서 `X-Forwarded-Proto` 헤더를 override하기 때문에 secure cookie와 rate limit이 의도한 대로 동작하지 않습니다.
- secure cookie를 사용하려면 `X-Forwarded-Proto` 헤더 값이 "https"여야 하지만, 이 경우 "http"로 설정됩니다.

따라서 `taxi-proxy` nginx 컨테이너에서 `X-Forwarded-Proto` 헤더를 rewrite하지 않고, 호스트 서버의 nginx에서 해당 헤더를 rewrite하도록 수정합니다.

## Further issues
- 없음.